### PR TITLE
Add support for default styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A simple card to display big numbers for sensors. It also supports severity leve
 | entity | string | **Required** | `sensor.my_temperature`
 | min | number | optional | Minimum value. If specified you get bar display
 | max | number | optional | Maximum value. Must be specified if you added min
+| color | string | `var(--primary-text-color)` | Default font color. Can be either hex or HA variable. Example: 'var(--secondary-text-color)'
 | style | string| `var(--label-badge-blue)` | Default bar color. Can be either hex or HA variable. Example: 'var(--label-badge-green)'
 | from | string | left | Direction from where the bar will start filling (must have min/max specified)
 | severity | list | optional | A list of severity objects. Items in list must be ascending based on 'value'
@@ -23,7 +24,8 @@ Severity object
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------
 | value | number | **Required** | Value until which to use this severity
-| style | number | **Required** | Color of severity. Can be either hex or HA variable. Example: 'var(--label-badge-green)'
+| style | string | **Required** | Color of severity. Can be either hex or HA variable. Example: 'var(--label-badge-green)'
+| color | string | `var(--primary-text-color)` | Font color of the severity. Can be either hex or HA variable. Example: 'var(--secondary-text-color)'
 
 ### WARNINGS
 - Make sure you use ascending object values to have consistent behaviour
@@ -39,6 +41,7 @@ Severity object
   from: bottom
   min: 0
   max: 100
+  color: '#000000'
   style: 'var(--label-badge-blue)'
   severity:
     - value: 70
@@ -47,4 +50,5 @@ Severity object
       style: 'var(--label-badge-yellow)'
     - value: 100
       style: 'var(--label-badge-red)'
+      color: '#FFFFFF'
 ```

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A simple card to display big numbers for sensors. It also supports severity leve
 | entity | string | **Required** | `sensor.my_temperature`
 | min | number | optional | Minimum value. If specified you get bar display
 | max | number | optional | Maximum value. Must be specified if you added min
+| style | string| optional | Default bar color. Can be either hex or HA variable. Example: 'var(--label-badge-green)'
 | from | string | left | Direction from where the bar will start filling (must have min/max specified)
 | severity | list | optional | A list of severity objects. Items in list must be ascending based on 'value'
 
@@ -38,6 +39,7 @@ Severity object
   from: bottom
   min: 0
   max: 100
+  style: 'var(--label-badge-blue)'
   severity:
     - value: 70
       style: 'var(--label-badge-green)'

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A simple card to display big numbers for sensors. It also supports severity leve
 | entity | string | **Required** | `sensor.my_temperature`
 | min | number | optional | Minimum value. If specified you get bar display
 | max | number | optional | Maximum value. Must be specified if you added min
-| style | string| optional | Default bar color. Can be either hex or HA variable. Example: 'var(--label-badge-green)'
+| style | string| `var(--label-badge-blue)` | Default bar color. Can be either hex or HA variable. Example: 'var(--label-badge-green)'
 | from | string | left | Direction from where the bar will start filling (must have min/max specified)
 | severity | list | optional | A list of severity objects. Items in list must be ascending based on 'value'
 

--- a/bignumber-card.js
+++ b/bignumber-card.js
@@ -1,5 +1,6 @@
 class BigNumberCard extends HTMLElement {
   _DEFAULT_STYLE = 'var(--label-badge-blue)';
+  _DEFAULT_COLOR = 'var(--primary-text-color)';
   
   constructor() {
     super();
@@ -25,6 +26,7 @@ class BigNumberCard extends HTMLElement {
     style.textContent = `
       ha-card {
         text-align: center;
+        --bignumber-color: ${this._getColor(null, cardConfig)};
         --bignumber-fill-color: ${this._getStyle(null, cardConfig)};
         --bignumber-percent: 100%;
         --bignumber-direction: ${cardConfig.from};
@@ -35,12 +37,12 @@ class BigNumberCard extends HTMLElement {
       #value {
         font-size: calc(var(--base-unit) * 1.3);
         line-height: calc(var(--base-unit) * 1.3);
-        color: var(--primary-text-color);
+        color: var(--bignumber-color);
       }
       #title {
         font-size: calc(var(--base-unit) * 0.5);
         line-height: calc(var(--base-unit) * 0.5);
-        color: var(--primary-text-color);
+        color: var(--bignumber-color);
       }
     `;
     card.appendChild(content);
@@ -70,19 +72,26 @@ class BigNumberCard extends HTMLElement {
   _computeSeverity(stateValue, sections) {
     if (stateValue === undefined || stateValue === null) return;
     const numberValue = Number(stateValue);
-    let style;
-    sections.forEach(section => {
-      if (numberValue <= section.value && !style) {
-        style = section.style;
-      }
-    });
-    return style;
+    for (const section of sections) {
+      if (numberValue <= section.value) return section;
+    }
+  }
+
+  _getColor(entityState, config) {
+    if (config.severity) {
+      const severity = this._computeSeverity(entityState, config.severity);
+      console.log('_getColor', entityState, config, severity);
+      if (severity && severity.color) return severity.color;
+    }
+    if (config.color) return config.color;
+    return this._DEFAULT_COLOR;
   }
 
   _getStyle(entityState, config) {
     if (config.severity) {
-      const style = this._computeSeverity(entityState, config.severity);
-      if (style) return style;
+      const severity = this._computeSeverity(entityState, config.severity);
+      console.log('_getStyle', entityState, config, severity);
+      if (severity && severity.style) return severity.style;
     }
     if (config.style) return config.style;
     return this._DEFAULT_STYLE;
@@ -103,6 +112,7 @@ class BigNumberCard extends HTMLElement {
         root.querySelector("ha-card").style.setProperty('--bignumber-percent', `${this._translatePercent(entityState, config.min, config.max)}%`);
       }
       root.querySelector("ha-card").style.setProperty('--bignumber-fill-color', `${this._getStyle(entityState, config)}`);
+      root.querySelector("ha-card").style.setProperty('--bignumber-color', `${this._getColor(entityState, config)}`);
       root.getElementById("value").textContent = `${entityState} ${measurement}`;
       this._entityState = entityState
     }

--- a/bignumber-card.js
+++ b/bignumber-card.js
@@ -1,4 +1,6 @@
 class BigNumberCard extends HTMLElement {
+  _DEFAULT_STYLE = 'var(--label-badge-blue)';
+  
   constructor() {
     super();
     this.attachShadow({ mode: 'open' });
@@ -23,7 +25,7 @@ class BigNumberCard extends HTMLElement {
     style.textContent = `
       ha-card {
         text-align: center;
-        --bignumber-fill-color: var(--label-badge-blue);
+        --bignumber-fill-color: ${this._getStyle(null, cardConfig)};
         --bignumber-percent: 100%;
         --bignumber-direction: ${cardConfig.from};
         --base-unit: ${cardConfig.scale};
@@ -66,6 +68,7 @@ class BigNumberCard extends HTMLElement {
   }
 
   _computeSeverity(stateValue, sections) {
+    if (stateValue === undefined || stateValue === null) return;
     const numberValue = Number(stateValue);
     let style;
     sections.forEach(section => {
@@ -73,7 +76,16 @@ class BigNumberCard extends HTMLElement {
         style = section.style;
       }
     });
-    return style || 'var(--label-badge-blue)';
+    return style;
+  }
+
+  _getStyle(entityState, config) {
+    if (config.severity) {
+      const style = this._computeSeverity(entityState, config.severity);
+      if (style) return style;
+    }
+    if (config.style) return config.style;
+    return this._DEFAULT_STYLE;
   }
 
   _translatePercent(value, min, max) {
@@ -90,9 +102,7 @@ class BigNumberCard extends HTMLElement {
       if (config.min !== undefined && config.max !== undefined) {
         root.querySelector("ha-card").style.setProperty('--bignumber-percent', `${this._translatePercent(entityState, config.min, config.max)}%`);
       }
-      if (config.severity) {
-        root.querySelector("ha-card").style.setProperty('--bignumber-fill-color', `${this._computeSeverity(entityState, config.severity)}`);
-      }
+      root.querySelector("ha-card").style.setProperty('--bignumber-fill-color', `${this._getStyle(entityState, config)}`);
       root.getElementById("value").textContent = `${entityState} ${measurement}`;
       this._entityState = entityState
     }

--- a/bignumber-card.js
+++ b/bignumber-card.js
@@ -80,7 +80,6 @@ class BigNumberCard extends HTMLElement {
   _getColor(entityState, config) {
     if (config.severity) {
       const severity = this._computeSeverity(entityState, config.severity);
-      console.log('_getColor', entityState, config, severity);
       if (severity && severity.color) return severity.color;
     }
     if (config.color) return config.color;
@@ -90,7 +89,6 @@ class BigNumberCard extends HTMLElement {
   _getStyle(entityState, config) {
     if (config.severity) {
       const severity = this._computeSeverity(entityState, config.severity);
-      console.log('_getStyle', entityState, config, severity);
       if (severity && severity.style) return severity.style;
     }
     if (config.style) return config.style;


### PR DESCRIPTION
Allows to add a style config property to assign a default colour for the big number card graph.

Added both code and documentation changes.