### PR TITLE
Support showing entity attribute values

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A simple card to display big numbers for sensors. It also supports severity leve
 | title | string | optional | Name to display on card
 | scale | string | 50px | Base scale for card: '50px'
 | entity | string | **Required** | `sensor.my_temperature`
+| attribute | string | optional | the entity attribute you want to display e.g. `current_temperature`.  The entity state will be shown if not defined.
 | min | number | optional | Minimum value. If specified you get bar display
 | max | number | optional | Maximum value. Must be specified if you added min
 | color | string | `var(--primary-text-color)` | Default font color. Can be either hex or HA variable. Example: 'var(--secondary-text-color)'

--- a/bignumber-card.js
+++ b/bignumber-card.js
@@ -107,7 +107,9 @@ class BigNumberCard extends HTMLElement {
   set hass(hass) {
     const config = this._config;
     const root = this.shadowRoot;
-    const entityState = hass.states[config.entity].state;
+    const entityState = config.attribute 
+      ? hass.states[config.entity].attributes[config.attribute] 
+      : hass.states[config.entity].state;
     const measurement = hass.states[config.entity].attributes.unit_of_measurement || "";
 
     if (entityState !== this._entityState) {


### PR DESCRIPTION
Natively allows people to define attribute names to pull data from entities

E.g.

```
  - type: custom:bignumber-card
    entity: climate.livingroom
    attribute: temperature
```