### PR TITLE
added option to control opacity of unit of measure

### DIFF
--- a/bignumber-card.js
+++ b/bignumber-card.js
@@ -16,6 +16,7 @@ class BigNumberCard extends HTMLElement {
     const cardConfig = Object.assign({}, config);
     if (!cardConfig.scale) cardConfig.scale = "50px";
     if (!cardConfig.from) cardConfig.from = "left";
+    if (!cardConfig.opacity) cardConfig.opacity = "0.5";
     if (!cardConfig.noneString) cardConfig.nonestring = null;
     if (!cardConfig.noneCardClass) cardConfig.noneCardClass = null;
     if (!cardConfig.noneValueClass) cardConfig.noneValueClass = null;
@@ -44,7 +45,7 @@ class BigNumberCard extends HTMLElement {
         line-height: calc(var(--base-unit) * 1.3);
         color: var(--bignumber-color);
       }
-      #value small{opacity: 0.5}
+      #value small{opacity: ${cardConfig.opacity}}
       #title {
         font-size: calc(var(--base-unit) * 0.5);
         line-height: calc(var(--base-unit) * 0.5);


### PR DESCRIPTION
I'm using this card for a weather clock project, and the unit of measurement was hard to see from a distance.  I added this option to be able to change the opacity of the unit of measurement and thought I would share it back.